### PR TITLE
Compute recursions in polygon only if object returned

### DIFF
--- a/tests/testthat/test_recurse.R
+++ b/tests/testthat/test_recurse.R
@@ -227,9 +227,12 @@ test_that("polygon",
 			  	expect_equal(recursions$revisits, 2)
 			  	expect_equal(round(as.numeric(recursions$revisitStats$timeInside[1]), digits = 2), 44.99)
 			  	expect_equal(round(as.numeric(recursions$revisitStats$timeInside[2]), digits = 2), 108.9)
-			  	
-			  	recursions2 = getRecursionsInPolygon(createMove2Obj(track), polyc)
-			  	expect_equal(recursions2$revisits, 2)
+
+				obj <- createMove2Obj(track)
+				if (!is.null(obj)) {
+			  		recursions2 = getRecursionsInPolygon(obj, polyc)
+			  		expect_equal(recursions2$revisits, 2)
+				}	
 		  	}
 		  })
 


### PR DESCRIPTION
This change makes the test a little more robust to whether `move2` is installed or not -- as it wasn't on my test machine leading to test failure that was a false positive.

You can of course rewrite this, or use one `testthat`'s `skip_if_*` predicates, or ...   